### PR TITLE
Add SCI Student Success guide

### DIFF
--- a/config/newGuides.ts
+++ b/config/newGuides.ts
@@ -10,6 +10,7 @@ export const newGuides = [
   "career/running-for-officer", // Running for PittCSC Officer - NEW
   "career/working-at-startup", // Working at a Startup - NEW
   "skills/csc-dev-lab/0-what-is-csc-dev-lab", // What is CSC Dev Lab - NEW
+  "skills/student-success", // SCI Student Success - NEW
 ]
 
 export const updatedGuides = [

--- a/data/guides/skills/student-success.md
+++ b/data/guides/skills/student-success.md
@@ -51,17 +51,19 @@ Midterms got you stressed? Student Success hosts Boba Bonanza around midterm sea
 
 ### Breakfast for Dinner
 
-The Friday before finals week, they do Breakfast for Dinner. Pancakes, bacon, the works. It's basically a pre-finals hangout where you can grab food and, if you want, you can meet with TAs and professors to get ahead on studying. 
+The Friday before finals week, they do Breakfast for Dinner. Pancakes, bacon, the works. It's basically a pre-finals hangout where you can grab food and, if you want, you can meet with TAs and professors to get ahead on studying.
 
 ## How to Reach Out
 
 Everything is virtual, so you don't need to go anywhere.
 
 **The Team:**
+
 - **[Lynnsey Doane](https://www.sci.pitt.edu/people/lynnsey-doane)** - Director of Student Success
 - **[Kailyn Lukaszewski](https://www.sci.pitt.edu/people/kailyn-lukaszewski)** - Student Success Coordinator
 
 **Contact:**
+
 - Email: [askscisuccess@pitt.edu](mailto:askscisuccess@pitt.edu)
 - Schedule through [Navigate Student](https://pitt.navigate.eab.com/)
 

--- a/data/guides/skills/student-success.md
+++ b/data/guides/skills/student-success.md
@@ -1,0 +1,74 @@
+---
+title: "SCI Student Success"
+
+search_tags:
+  [
+    "student success",
+    "support",
+    "wellness",
+    "boba bonanza",
+    "breakfast for dinner",
+    "advising",
+    "academic support",
+    "navigate",
+    "lynnsey doane",
+    "kailyn lukaszewski",
+  ]
+---
+
+The School of Computing and Information (SCI) has a dedicated Student Success team here to support you throughout your time at Pitt. They handle everything from course planning to helping you figure out what to do when you're stuck.
+
+## About the Team
+
+[Lynnsey Doane](https://www.sci.pitt.edu/people/lynnsey-doane) (Director) and [Kailyn Lukaszewski](https://www.sci.pitt.edu/people/kailyn-lukaszewski) (Coordinator) work with SCI students on academic stuff, but they also help with the non-academic parts of being a student. If you're trying to figure out your schedule, dealing with a rough semester, or just want to talk through something, they're available.
+
+## What They Do
+
+They can help with:
+
+- **Academic stuff**
+  - Course planning and scheduling
+  - Figuring out degree requirements
+  - What to do when you're struggling in a class
+- **Personal stuff**
+  - Stress management
+  - Finding campus resources
+  - Talking through challenges
+- **Skills**
+  - Time management
+  - Study strategies
+  - Goal setting
+- **Finding opportunities**
+  - Research positions
+  - Internships
+  - Getting involved on campus
+
+## Events
+
+### Boba Bonanza
+
+Midterms got you stressed? Student Success hosts Boba Bonanza around midterm season. Free boba, other SCI students, and a break from studying. It's pretty popular—worth checking out if you need a breather.
+
+### Breakfast for Dinner
+
+The Friday before finals week, they do Breakfast for Dinner. Pancakes, bacon, the works. It's basically a pre-finals hangout where you can grab food and, if you want, you can meet with TAs and professors to get ahead on studying. 
+
+## How to Reach Out
+
+Everything is virtual, so you don't need to go anywhere.
+
+**The Team:**
+- **[Lynnsey Doane](https://www.sci.pitt.edu/people/lynnsey-doane)** - Director of Student Success
+- **[Kailyn Lukaszewski](https://www.sci.pitt.edu/people/kailyn-lukaszewski)** - Student Success Coordinator
+
+**Contact:**
+- Email: [askscisuccess@pitt.edu](mailto:askscisuccess@pitt.edu)
+- Schedule through [Navigate Student](https://pitt.navigate.eab.com/)
+
+You don't need to have a specific problem to reach out. If you're not sure what you need, that's fine - they can help you figure it out.
+
+## When to Use It
+
+You don't have to be struggling to use Student Success. Some people reach out because they're doing well and want to do better. Others just want to talk through a decision or check in with someone. It's there for whatever you need.
+
+For more information and up-to-date details, check out the [official SCI Student Success page](https://www.sci.pitt.edu/student-services/student-success).


### PR DESCRIPTION
## Summary
- Adds a new guide about SCI's Student Success team under `/guides/skills/student-success`
- Covers team members, services, events (Boba Bonanza, Breakfast for Dinner), and how to connect
- Marks the guide as "new" in `newGuides.ts` to highlight it for users